### PR TITLE
add new trigger events

### DIFF
--- a/custom_components/sleep_as_android/device_trigger.py
+++ b/custom_components/sleep_as_android/device_trigger.py
@@ -23,6 +23,7 @@ TRIGGERS = [
     "alarm_alert_start",
     "alarm_alert_dismiss",
     "alarm_skip_next",
+    "show_skip_next_alarm",
     "rem",
     "smart_period",
     "before_smart_period",
@@ -39,7 +40,8 @@ TRIGGERS = [
     "sound_event_talk",
     "sound_event_cough",
     "sound_event_baby",
-    "sound_event_laugh"
+    "sound_event_laugh",
+    "before_alarm"
 ]
 
 TRIGGER_SCHEMA = HA_TRIGGER_BASE_SCHEMA.extend(


### PR DESCRIPTION
`show_skip_next_alarm` can be found in the [documentation](https://docs.sleep.urbandroid.org/services/automation.html#events)
`before_alarm `is available on my device with the latest version of sleep as android